### PR TITLE
replace error that had been removed

### DIFF
--- a/protocol/dhcp/dhcp.go
+++ b/protocol/dhcp/dhcp.go
@@ -173,7 +173,7 @@ func (d *DHCP) Read(b []byte) (n int, err error) {
 
 func (d *DHCP) Write(b []byte) (n int, err error) {
 	if len(b) < 240 {
-		return 0, ErrTruncated
+		return 0, errors.New("incomplete packet")
 	}
 	buf := bytes.NewBuffer(b)
 


### PR DESCRIPTION
This `ErrTruncated` variable was once defined when the method was alongside pacit.  It was lost somewhere in refactoring.